### PR TITLE
safely parse integers

### DIFF
--- a/src/Data/Version/Internal.purs
+++ b/src/Data/Version/Internal.purs
@@ -1,16 +1,16 @@
 module Data.Version.Internal where
 
 import Prelude hiding (when)
-import Data.Int (fromString)
-import Data.Char.Unicode (toLower)
-import Data.String.CodeUnits (fromCharArray)
-import Data.List (List(), toUnfoldable, some, null)
-import Data.Maybe (fromJust)
+
 import Control.Monad.State.Class (gets)
-import Text.Parsing.Parser (Parser(), ParseState(..), fail)
+import Data.Char.Unicode (toLower)
+import Data.Int (fromString)
+import Data.List (List, toUnfoldable, some, null)
+import Data.Maybe (maybe)
+import Data.String.CodeUnits (fromCharArray)
+import Text.Parsing.Parser (Parser, ParseState(..), fail)
+import Text.Parsing.Parser.Pos (Position, initialPos)
 import Text.Parsing.Parser.Token (when, match)
-import Text.Parsing.Parser.Pos (Position(), initialPos)
-import Partial.Unsafe (unsafePartial)
 
 isDigit :: Char -> Boolean
 isDigit c = '0' <= c && c <= '9'
@@ -19,9 +19,10 @@ isAsciiAlpha :: Char -> Boolean
 isAsciiAlpha ch = between 'a' 'z' (toLower ch)
 
 nonNegativeInt :: Parser (List Char) Int
-nonNegativeInt = fromDigits <$> some (when lieAboutPos isDigit)
+nonNegativeInt =
+  intFromList <$> some (when lieAboutPos isDigit) >>= maybe (fail "invalid 32-bit integer") pure
   where
-  fromDigits digits = unsafePartial $ fromJust $ fromString $ fromCharArray $ toUnfoldable digits
+  intFromList = fromString <<< fromCharArray <<< toUnfoldable
 
 lieAboutPos :: forall a. a -> Position
 lieAboutPos = const initialPos

--- a/test/Haskell.purs
+++ b/test/Haskell.purs
@@ -1,16 +1,16 @@
 module Test.Haskell where
 
 import Prelude
-import Data.Tuple
-import Data.List
-import Data.Either
-import Data.Foldable
-import Effect
-import Effect.Exception
-import Effect.Console hiding (error)
+import Data.Tuple (Tuple(..))
+import Data.List (fromFoldable)
+import Data.Either (Either(..))
+import Data.Foldable (for_)
+import Effect (Effect)
+import Effect.Exception (throw)
+import Effect.Console (log)
 
-import Data.Version.Haskell
-import Test.Utils
+import Data.Version.Haskell (Version(..), parseVersion, showVersion)
+import Test.Utils (assertEqual, assertSuccess)
 
 testVersions :: Array (Tuple String Version)
 testVersions =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,12 +1,11 @@
 module Test.Main where
 
 import Prelude
-import Effect
-import Effect.Console hiding (error)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Test.Haskell as Haskell
 import Test.Version as Version
-import Test.Utils
 
 main :: Effect Unit
 main = do

--- a/test/Version.purs
+++ b/test/Version.purs
@@ -1,20 +1,19 @@
 module Test.Version where
 
 import Prelude
-import Data.Tuple
-import Data.List hiding (sort)
-import Data.Either
-import Data.Foldable
-import Data.Traversable
+import Data.Tuple (Tuple(..))
+import Data.List (List(..), fromFoldable)
+import Data.Either (Either(..))
+import Data.Traversable (for_, traverse)
 import Data.Array (sort)
 import Data.Maybe (fromJust)
-import Effect
-import Effect.Exception
-import Effect.Console hiding (error)
-import Partial.Unsafe
+import Effect (Effect)
+import Effect.Exception (throw)
+import Effect.Console (log)
+import Partial.Unsafe (unsafePartial)
 
-import Data.Version
-import Test.Utils
+import Data.Version (Version, numeric, parseVersion, showVersion, textual, version)
+import Test.Utils (assertEqual, assertSuccess)
 
 testVersions :: Array (Tuple String Version)
 testVersions = normals <> pres <> metas
@@ -56,6 +55,8 @@ invalidVersions =
   , "."
   , "13."
   , ".6"
+  , ""
+  , "2147483648.0.0"
   ]
 
 -- Taken from the semver spec. These should be in increasing order of


### PR DESCRIPTION
We were running into a failed pattern match error when entering a version that's too big and tracked it down to the `unsafePartial fromJust` in here.