### PR TITLE
Update for PureScript 0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /bower_components/
 /node_modules/
 /output/
-/.psci*
+/.psc*
 /src/.webpack.js

--- a/bower.json
+++ b/bower.json
@@ -9,23 +9,23 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/hdgarrood/purescript-versions"
+    "url": "https://github.com/hdgarrood/purescript-versions"
   },
   "dependencies": {
-    "purescript-console": "^4.0.0",
-    "purescript-either": "^4.0.0",
-    "purescript-maybe": "^4.0.0",
-    "purescript-integers": "^4.0.0",
-    "purescript-strings": "^4.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-functions": "^4.0.0",
-    "purescript-foldable-traversable": "^4.0.0",
-    "purescript-control": "^4.0.0",
-    "purescript-parsing": "^5.0.1",
-    "purescript-partial": "^2.0.0",
-    "purescript-orders": "^4.0.0"
+    "purescript-console": "^5.0.0",
+    "purescript-either": "^5.0.0",
+    "purescript-maybe": "^5.0.0",
+    "purescript-integers": "^5.0.0",
+    "purescript-strings": "^5.0.0",
+    "purescript-lists": "^6.0.0",
+    "purescript-functions": "^5.0.0",
+    "purescript-foldable-traversable": "^5.0.0",
+    "purescript-control": "^5.0.0",
+    "purescript-parsing": "^6.0.0",
+    "purescript-partial": "^3.0.0",
+    "purescript-orders": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-exceptions": "^4.0.0"
+    "purescript-exceptions": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^12.2.0"
+    "pulp": "^15.0.0"
   }
 }

--- a/src/Data/Version/Haskell.purs
+++ b/src/Data/Version/Haskell.purs
@@ -9,15 +9,15 @@
 -- | though, you should probably be using `Data.Version`.
 module Data.Version.Haskell where
 
-import Prelude 
+import Prelude
+
 import Data.Either (Either)
 import Data.List (List(..), toUnfoldable, fromFoldable, some)
 import Data.String (joinWith)
 import Data.String.CodeUnits (fromCharArray, toCharArray)
-import Text.Parsing.Parser (Parser(), ParseError(), runParser)
+import Data.Version.Internal (eof, match', nonNegativeInt, isDigit, isAsciiAlpha, when')
+import Text.Parsing.Parser (Parser, ParseError, runParser)
 import Text.Parsing.Parser.Combinators (sepBy, sepBy1, option)
-
-import Data.Version.Internal (eof, match', nonNegativeInt, isDigit, isAsciiAlpha, when') 
 
 -- | A version consists of any number of integer components, and any number of
 -- | string components.
@@ -36,7 +36,7 @@ versionParser = do
   as <- nonNegativeInt `sepBy1` match' '.'
   bs <- option Nil (hyphen *> identifier `sepBy` hyphen)
   eof
-  pure $ Version as bs
+  pure $ Version (fromFoldable as) bs
 
   where
   hyphen = match' '-'

--- a/src/Data/Version/Haskell.purs
+++ b/src/Data/Version/Haskell.purs
@@ -13,6 +13,7 @@ import Prelude
 
 import Data.Either (Either)
 import Data.List (List(..), toUnfoldable, fromFoldable, some)
+import Data.List.Types (NonEmptyList)
 import Data.String (joinWith)
 import Data.String.CodeUnits (fromCharArray, toCharArray)
 import Data.Version.Internal (eof, match', nonNegativeInt, isDigit, isAsciiAlpha, when')
@@ -21,10 +22,10 @@ import Text.Parsing.Parser.Combinators (sepBy, sepBy1, option)
 
 -- | A version consists of any number of integer components, and any number of
 -- | string components.
-data Version = Version (List Int) (List String)
+data Version = Version (NonEmptyList Int) (List String)
 
 showVersion :: Version -> String
-showVersion (Version as bs) = f as <> prefix "-" (joinWith "-" (toUnfoldable bs))
+showVersion (Version as bs) = f (fromFoldable as) <> prefix "-" (joinWith "-" (toUnfoldable bs))
   where
   f = joinWith "." <<< toUnfoldable <<< map show
 
@@ -36,7 +37,7 @@ versionParser = do
   as <- nonNegativeInt `sepBy1` match' '.'
   bs <- option Nil (hyphen *> identifier `sepBy` hyphen)
   eof
-  pure $ Version (fromFoldable as) bs
+  pure $ Version as bs
 
   where
   hyphen = match' '-'

--- a/src/Data/Version/Haskell.purs
+++ b/src/Data/Version/Haskell.purs
@@ -20,7 +20,7 @@ import Data.Version.Internal (eof, match', nonNegativeInt, isDigit, isAsciiAlpha
 import Text.Parsing.Parser (Parser, ParseError, runParser)
 import Text.Parsing.Parser.Combinators (sepBy, sepBy1, option)
 
--- | A version consists of any number of integer components, and any number of
+-- | A version consists of at least one integer component, and any number of
 -- | string components.
 data Version = Version (NonEmptyList Int) (List String)
 

--- a/src/Data/Version/Internal.purs
+++ b/src/Data/Version/Internal.purs
@@ -3,10 +3,11 @@ module Data.Version.Internal where
 import Prelude hiding (when)
 
 import Control.Monad.State.Class (gets)
-import Data.Char.Unicode (toLower)
+import Data.CodePoint.Unicode (toLowerSimple)
 import Data.Int (fromString)
 import Data.List (List, toUnfoldable, some, null)
 import Data.Maybe (maybe)
+import Data.String (codePointFromChar)
 import Data.String.CodeUnits (fromCharArray)
 import Text.Parsing.Parser (Parser, ParseState(..), fail)
 import Text.Parsing.Parser.Pos (Position, initialPos)
@@ -16,7 +17,8 @@ isDigit :: Char -> Boolean
 isDigit c = '0' <= c && c <= '9'
 
 isAsciiAlpha :: Char -> Boolean
-isAsciiAlpha ch = between 'a' 'z' (toLower ch)
+isAsciiAlpha =
+  between (codePointFromChar 'a') (codePointFromChar 'z') <<< toLowerSimple <<< codePointFromChar
 
 nonNegativeInt :: Parser (List Char) Int
 nonNegativeInt =

--- a/test/Haskell.purs
+++ b/test/Haskell.purs
@@ -1,15 +1,18 @@
 module Test.Haskell where
 
 import Prelude
-import Data.Tuple (Tuple(..))
-import Data.List (fromFoldable)
+
 import Data.Either (Either(..))
 import Data.Foldable (for_)
-import Effect (Effect)
-import Effect.Exception (throw)
-import Effect.Console (log)
-
+import Data.List (fromFoldable)
+import Data.List.NonEmpty as NonEmptyList
+import Data.Maybe (fromJust)
+import Data.Tuple (Tuple(..))
 import Data.Version.Haskell (Version(..), parseVersion, showVersion)
+import Effect (Effect)
+import Effect.Console (log)
+import Effect.Exception (throw)
+import Partial.Unsafe (unsafePartial)
 import Test.Utils (assertEqual, assertSuccess)
 
 testVersions :: Array (Tuple String Version)
@@ -23,7 +26,7 @@ testVersions =
   , Tuple "12"            $ v [12] []
   ]
   where
-  v as bs = Version (fromFoldable as) (fromFoldable bs)
+  v as bs = Version (unsafePartial fromJust $ NonEmptyList.fromFoldable as) (fromFoldable bs)
 
 invalidVersions :: Array String
 invalidVersions =


### PR DESCRIPTION
This PR updates for PureScript 0.14 by taking the following actions:

1. Updated the bower link to match the registry url for this package
2. Updated dependencies to their new major versions in bower
3. Updated the Pulp dependency in package.json to v15, for compatibility with PureScript 0.14
4. Made changes to the code to accommodate changes in the `unicode` and `parsing` libraries (full comments in the code inline below).

I've verified this builds and passes with `pulp build` and `pulp test`.